### PR TITLE
Upgrade to Vanilla Framework v1.1.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
    "gulp-sourcemaps": "^2.4.0",
-   "vanilla-framework": "1.1.7",
+   "vanilla-framework": "1.1.9",
    "gulp-util": "^3.0.8"
  }
 }

--- a/scss/_patterns_heading-icon.scss
+++ b/scss/_patterns_heading-icon.scss
@@ -20,7 +20,7 @@
     }
 
     &__title {
-      @extend %heading-3;
+      @include heading-3;
       margin-bottom: 0;
     }
 

--- a/scss/_patterns_media-object.scss
+++ b/scss/_patterns_media-object.scss
@@ -18,7 +18,7 @@
     }
 
     &__title {
-      @extend %heading-4;
+      @include heading-4;
       margin-bottom: .5rem;
     }
 

--- a/scss/_patterns_strip.scss
+++ b/scss/_patterns_strip.scss
@@ -6,7 +6,10 @@
 @mixin theme-p-strip--accent {
 
   .p-strip--accent {
-    @extend %strip;
+    // XXX: Ant - Replace with @include strip;
+    // Once this issue is fixed:
+    // https://github.com/vanilla-framework/vanilla-framework/issues/961
+    @extend .p-strip;
     background-color: $color-accent;
     color: determine-text-color($color-accent);
   }
@@ -15,7 +18,10 @@
 @mixin theme-p-strip--image {
 
   .p-strip--image {
-    @extend %strip;
+    // XXX: Ant - Replace with @include strip;
+    // Once this issue is fixed:
+    // https://github.com/vanilla-framework/vanilla-framework/issues/961
+    @extend .p-strip;
     background-repeat: no-repeat;
     background-size: cover;
 


### PR DESCRIPTION
## Done
Upgraded Vanilla Framework to v1.1.9 and tweaked the theme to align with changes in Vanilla.

## QA
- Pull branch
- Follow the README to get installed
- Run `gulp build` and see there are no errors
- Run `gulp jekyll`, click around the patterns and see they are the same as you expect

## Details
Fixes https://github.com/vanilla-framework/vanilla-brochure-theme/issues/52

_There is a hack to get around an issue on Vanilla Framework. It has been commented as to be mended with the next release_