### PR TITLE
Removing 'only' from image positions and card files

### DIFF
--- a/scss/_patterns_card.scss
+++ b/scss/_patterns_card.scss
@@ -12,7 +12,7 @@
       color: $color-dark;
       padding: 1.3333rem;
 
-      @media only (min-width: $breakpoint-medium) {
+      @media (min-width: $breakpoint-medium) {
         padding: 1.25rem;
       }
     }

--- a/scss/_utilities_image-position.scss
+++ b/scss/_utilities_image-position.scss
@@ -2,7 +2,7 @@
 
 @mixin theme-u-image-position {
   .u-image-position {
-    @media only (min-width: $breakpoint-medium) {
+    @media (min-width: $breakpoint-medium) {
       position: relative;
 
       [class*='col-'] {


### PR DESCRIPTION
# Done 

Removed rogue ```only``` properties in two media queries. Forces the SCSS not to build when not dependant on gulp. Relates to PR https://github.com/vanilla-framework/vanilla-framework/pull/1017

# QA 

- Pull down code
- Run ```gulp build``` 
- Check for errors or issues on mobile