### PR TITLE
Update Vanilla-framework to v1.2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,14 +34,13 @@
     "gulp-sass": "3.1.0",
     "gulp-sass-lint": "1.3.2",
     "gulp-shell": "^0.5.2",
-    "gulp-util": "^3.0.7",
     "browser-sync": "^2.18.6",
     "gulp-concat": "^2.6.1",
+    "gulp-sourcemaps": "^2.4.0",
+    "gulp-util": "^3.0.8",
     "wrench": "^1.5.9"
   },
   "dependencies": {
-   "gulp-sourcemaps": "^2.4.0",
-   "vanilla-framework": "1.1.x",
-   "gulp-util": "^3.0.8"
+   "vanilla-framework": "1.2.x"
  }
 }


### PR DESCRIPTION
## Done
Updated the vanilla framework version to the latest and moved the other dependencies to devDeps as they are only required to run the internal examples site.

## QA
- Pull down the branch and run
```bash
bundle install
npm install
npm update
cat node_modules/vanilla-framework/package.json | grep version // should return 1.2.0
```
- Run the site with `gulp jekyll`
- Go to http://127.0.0.1:4001/vanilla-brochure-theme/
- Click through the patterns and check there is nothing broken

## Details
Fixes https://github.com/vanilla-framework/vanilla-brochure-theme/issues/70
