### PR TITLE
Ensure divider blocks are full height

### DIFF
--- a/examples/patterns/divider.html
+++ b/examples/patterns/divider.html
@@ -11,7 +11,7 @@ category: _patterns
   </div>
   <div class="col-4 p-divider__block">
     <h2>Dolor sit</h2>
-    <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quasi, labore at suscipit necessitatibus cumque commodi velit.</p>
+    <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quasi, labore at suscipit necessitatibus cumque commodi velit. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quasi, labore at suscipit necessitatibus cumque commodi velit. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Quasi, labore at suscipit necessitatibus cumque commodi velit.</p>
   </div>
   <div class="col-4 p-divider__block">
     <h2>Cumque commodi</h2>

--- a/scss/_patterns_divider.scss
+++ b/scss/_patterns_divider.scss
@@ -2,6 +2,10 @@
 
   .p-divider {
 
+    @media (min-width: $breakpoint-medium) {
+      display: flex;
+    }
+
     &__block {
       border-bottom: 1px solid $color-mid-light;
 


### PR DESCRIPTION
Related https://github.com/canonical-websites/www.ubuntu.com/issues/1684

## QA

- Pull code
- Run `gulp jekyll`
- Check [divider example](http://127.0.0.1:4001/vanilla-brochure-theme/examples/patterns/divider/)
- Verify diving borders are full height