### PR TITLE
Add is-bordered to the strip pattern

### DIFF
--- a/docs/patterns/_strip.md
+++ b/docs/patterns/_strip.md
@@ -74,3 +74,38 @@ These classes will then override the text color to ensure it remains visible.
   </div>
 </section>
 ```
+
+## Strip is-bordered
+This pattern is used to add a dividing border at the bottom of the strip.
+
+**Note** This should be used when two strips of the same type are used after each other.
+
+<section class="p-strip is-bordered">
+  <div class="row">
+    <h2>.p-strip is-bordered</h2>
+  </div>
+  <div class="row">
+    <div class="col-6">
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+    </div>
+    <div class="col-6">
+      <img src="http://placehold.it/150x150" alt="Placeholder image" />
+    </div>
+  </div>
+</section>
+
+```html
+<section class="p-strip is-bordered">
+  <div class="row">
+    <h2>.p-strip is-bordered</h2>
+  </div>
+  <div class="row">
+    <div class="col-6">
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+    </div>
+    <div class="col-6">
+      <img src="http://placehold.it/150x150" alt="Placeholder image" />
+    </div>
+  </div>
+</section>
+```

--- a/examples/patterns/strip/is-bordered.html
+++ b/examples/patterns/strip/is-bordered.html
@@ -1,0 +1,18 @@
+---
+layout: default
+title: Strip / is-bordered
+category: _patterns
+---
+<section class="p-strip is-bordered">
+  <div class="row">
+    <h2>.p-strip is-bordered</h2>
+  </div>
+  <div class="row">
+    <div class="col-6">
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+    </div>
+    <div class="col-6">
+      <img src="http://placehold.it/150x150" alt="Placeholder image" />
+    </div>
+  </div>
+</section>

--- a/scss/_patterns_strip.scss
+++ b/scss/_patterns_strip.scss
@@ -1,6 +1,7 @@
 @mixin theme-p-strip {
   @include theme-p-strip--accent;
   @include theme-p-strip--image;
+  @include theme-p-strip-is-bordered;
 }
 
 @mixin theme-p-strip--accent {
@@ -26,5 +27,11 @@
     &.is-dark {
       color: $color-x-light;
     }
+  }
+}
+
+@mixin theme-p-strip-is-bordered {
+  [class^='p-strip'].is-bordered {
+    border-bottom: 1px solid $color-mid-light;
   }
 }


### PR DESCRIPTION
## Done
Added is-bordered to the strip pattern

## QA
- Pull down this branch and run `gulp jekyll`
- Go to http://127.0.0.1:4001/vanilla-brochure-theme/examples/patterns/strip/is-bordered/
- Check that the pattern matches [the spec](https://github.com/ubuntudesign/vanilla-brochure-theme-design/blob/master/Strip/strip.md#strip-borders).

## Details
Fixes https://github.com/vanilla-framework/vanilla-brochure-theme/issues/61 