### PR TITLE
Add strip vertical padding

### DIFF
--- a/docs/patterns/_strip.md
+++ b/docs/patterns/_strip.md
@@ -109,3 +109,69 @@ This pattern is used to add a dividing border at the bottom of the strip.
   </div>
 </section>
 ```
+
+## Strip is-deep
+This state gives the strip larger vertical padding.
+
+<section class="p-strip--light is-deep">
+  <div class="row">
+    <h2>.p-strip is-deep</h2>
+  </div>
+  <div class="row">
+    <div class="col-6">
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+    </div>
+    <div class="col-6">
+      <img src="http://placehold.it/150x150" alt="Placeholder image" />
+    </div>
+  </div>
+</section>
+
+```html
+<section class="p-strip--light is-deep">
+  <div class="row">
+    <h2>.p-strip is-deep</h2>
+  </div>
+  <div class="row">
+    <div class="col-6">
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+    </div>
+    <div class="col-6">
+      <img src="http://placehold.it/150x150" alt="Placeholder image" />
+    </div>
+  </div>
+</section>
+```
+
+## Strip is-shallow
+This state gives the strip smaller vertical padding.
+
+<section class="p-strip--light is-shallow">
+  <div class="row">
+    <h2>.p-strip is-shallow</h2>
+  </div>
+  <div class="row">
+    <div class="col-6">
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+    </div>
+    <div class="col-6">
+      <img src="http://placehold.it/150x150" alt="Placeholder image" />
+    </div>
+  </div>
+</section>
+
+```html
+<section class="p-strip--light is-shallow">
+  <div class="row">
+    <h2>.p-strip is-shallow</h2>
+  </div>
+  <div class="row">
+    <div class="col-6">
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+    </div>
+    <div class="col-6">
+      <img src="http://placehold.it/150x150" alt="Placeholder image" />
+    </div>
+  </div>
+</section>
+```

--- a/examples/patterns/strip/deep.html
+++ b/examples/patterns/strip/deep.html
@@ -1,0 +1,18 @@
+---
+layout: default
+title: Strip / is-deep
+category: _patterns
+---
+<section class="p-strip--light is-deep">
+  <div class="row">
+    <h2>.p-strip is-deep</h2>
+  </div>
+  <div class="row">
+    <div class="col-6">
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+    </div>
+    <div class="col-6">
+      <img src="http://placehold.it/150x150" alt="Placeholder image" />
+    </div>
+  </div>
+</section>

--- a/examples/patterns/strip/shallow.html
+++ b/examples/patterns/strip/shallow.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Strip / is-deep
+title: Strip / is-shallow
 category: _patterns
 ---
 <section class="p-strip--light is-shallow">

--- a/examples/patterns/strip/shallow.html
+++ b/examples/patterns/strip/shallow.html
@@ -1,0 +1,18 @@
+---
+layout: default
+title: Strip / is-deep
+category: _patterns
+---
+<section class="p-strip--light is-shallow">
+  <div class="row">
+    <h2>.p-strip is-shallow</h2>
+  </div>
+  <div class="row">
+    <div class="col-6">
+      <p>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</p>
+    </div>
+    <div class="col-6">
+      <img src="http://placehold.it/150x150" alt="Placeholder image" />
+    </div>
+  </div>
+</section>

--- a/scss/_patterns_strip.scss
+++ b/scss/_patterns_strip.scss
@@ -1,11 +1,12 @@
 @mixin theme-p-strip {
   @include theme-p-strip--accent;
   @include theme-p-strip--image;
-  @include theme-p-strip-is-bordered;
+  @include theme-p-strip--bordered;
+  @include theme-p-strip--shallow;
+  @include theme-p-strip--deep;
 }
 
 @mixin theme-p-strip--accent {
-
   .p-strip--accent {
     @include strip;
     background-color: $color-accent;
@@ -14,7 +15,6 @@
 }
 
 @mixin theme-p-strip--image {
-
   .p-strip--image {
     @include strip;
     background-repeat: no-repeat;
@@ -30,8 +30,28 @@
   }
 }
 
-@mixin theme-p-strip-is-bordered {
+@mixin theme-p-strip--bordered {
   [class^='p-strip'].is-bordered {
     border-bottom: 1px solid $color-mid-light;
+  }
+}
+
+@mixin theme-p-strip--shallow {
+  [class^='p-strip'].is-shallow {
+    padding: $sp-large 0;
+
+    @media only screen and (min-width: $breakpoint-medium) {
+      padding: $sp-xx-large 0;
+    }
+  }
+}
+
+@mixin theme-p-strip--deep {
+  [class^='p-strip'].is-deep {
+    padding: $sp-xxx-large 0;
+
+    @media only screen and (min-width: $breakpoint-medium) {
+      padding: 6rem 0;
+    }
   }
 }


### PR DESCRIPTION
## Done
Added strip vertical padding states.

## QA
- Pull this branch and run `gulp jekyll`
- Go to http://127.0.0.1:4001/vanilla-brochure-theme/examples/patterns/strip/shallow/
- Go to http://127.0.0.1:4001/vanilla-brochure-theme/examples/patterns/strip/deep/
- Check they match [the specs](https://github.com/ubuntudesign/vanilla-brochure-theme-design/blob/master/Strip/strip.md#strip-vertical-padding).
- Check they are documented

## Details
Fixes https://github.com/vanilla-framework/vanilla-brochure-theme/issues/51
