### PR TITLE
Fix the wrapping of long stepped list titles

### DIFF
--- a/examples/patterns/lists/stepped-list-detailed.html
+++ b/examples/patterns/lists/stepped-list-detailed.html
@@ -40,7 +40,7 @@ category: _patterns
   <li class="p-list-step__item col-8">
     <h3 class="p-list-step__title">
       <span class="p-list-step__bullet">5</span>
-      Last but not least
+      Last but not least Last but not least Last but not least
     </h3>
     <p class="p-list-step__content">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed purus lorem, dictum vel dolor eu, tincidunt suscipit magna. Suspendisse dignissim nisl vitae turpis iaculis, ut tempor enim gravida.</p>
   </li>

--- a/scss/_patterns_stepped-lists.scss
+++ b/scss/_patterns_stepped-lists.scss
@@ -48,7 +48,10 @@
 
       @media (min-width: $breakpoint-medium) {
         .p-list-step__bullet {
+          left: -$grid-gutter-width * 3;
           margin-right: 1rem;
+          margin-left: 0;
+          position: absolute;
           top: 2.25rem;
         }
       }


### PR DESCRIPTION
## Done
Reverted the logic of the bullet pushing the content but instead now it's positioned on the content and moved to space on the left.

## QA
- Pull down this branch
- Run `gulp jekyll`
- Go to http://127.0.0.1:4001/vanilla-brochure-theme/examples/patterns/lists/stepped-list-detailed/
- Check that the last item with a long title is displayed correctly.
- Check smaller screens

## Details
Fixes https://github.com/vanilla-framework/vanilla-brochure-theme/issues/81

## Screenshots
![stepped list - detailed - vanilla brochure theme - examples](https://user-images.githubusercontent.com/1413534/26939489-5e85c8b8-4c6f-11e7-89b8-69f186dd3be4.png)
