### PR TITLE
Align the heading icon to the top

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "6.6.0"
+  - "6.10.2"
 before_install:
   - rvm install 2.2.5
 install:

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-gem 'jekyll', '~> 3.4.0'
+gem 'jekyll', '~> 3.5.0'
 
 require 'rbconfig'
 if RbConfig::CONFIG['target_os'] =~ /darwin(1[0-3])/i

--- a/scss/_patterns_heading-icon.scss
+++ b/scss/_patterns_heading-icon.scss
@@ -25,6 +25,7 @@
     }
 
     &__img {
+      align-self: flex-start;
       flex-shrink: 0;
       height: 2.6666rem;
       margin-right: 1rem;


### PR DESCRIPTION
## Done
Add flex-align start to the image of the heading icon pattern

## QA
- Pull down this branch
- Run `gulp jekyll`
- Go to http://127.0.0.1:4001/vanilla-brochure-theme/examples/patterns/heading-icon/
- Scale down so the title start wrapping
- Check the image remains at the top

## Details
Fixes https://github.com/vanilla-framework/vanilla-brochure-theme/issues/78

## Screenshots

![heading icon - vanilla brochure theme - examples](https://user-images.githubusercontent.com/1413534/26940063-3503547c-4c71-11e7-9f8f-30691c4392cc.png)
