### PR TITLE
Prevent .is-split from changing height of adjacent list items

### DIFF
--- a/examples/patterns/lists/split-list.html
+++ b/examples/patterns/lists/split-list.html
@@ -6,9 +6,9 @@ category: _patterns
 
 <ul class="p-list--divided is-split">
   <li class="p-list__item is-ticked">Lorem</li>
-  <li class="p-list__item is-ticked">Ipsum</li>
+  <li class="p-list__item is-ticked">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aenean nec ipsum augue. Ut arcu erat, lacinia sit amet justo quis. Lorem ipsum dolor sit amet, consectetur adipiscing elit.</li>
   <li class="p-list__item is-ticked">Dolor</li>
-  <li class="p-list__item is-ticked">Lorem</li>
+  <li class="p-list__item is-ticked">Aenean nec ipsum augue. Ut arcu erat, lacinia sit amet justo quis.</li>
   <li class="p-list__item is-ticked">Ipsum</li>
-  <li class="p-list__item is-ticked">Dolor</li>
+  <li class="p-list__item is-ticked">Ut arcu erat, lacinia sit amet justo quis.</li>
 </ul>

--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -12,19 +12,26 @@
     &.is-split {
 
       @media (min-width: $breakpoint-medium) {
-        display: flex;
-        flex-wrap: wrap;
 
-        .p-list__item {
-          width: calc(50% - .5rem);
+        @supports (columns: 1) {
+          columns: 2;
+        }
 
-          &:nth-child(2n-1) {
-            margin-right: 1rem;
+        @supports not (columns: 1) {
+          display: flex;
+          flex-wrap: wrap;
+
+          .p-list__item {
+            width: calc(50% - .5rem);
           }
+        }
 
-          &:nth-last-child(2) {
-            border-bottom: 0;
-          }
+        .p-list__item:last-of-type {
+          border-bottom: 1px dotted $color-mid-light;
+        }
+
+        &:nth-child(2n-1) {
+          margin-right: 1rem;
         }
       }
     }

--- a/scss/_patterns_lists.scss
+++ b/scss/_patterns_lists.scss
@@ -15,6 +15,11 @@
 
         @supports (columns: 1) {
           columns: 2;
+
+          .p-list__item {
+            display: inline-block;
+            width: 100%;
+          }
         }
 
         @supports not (columns: 1) {


### PR DESCRIPTION
## Done

Prevent .is-split from changing height of adjacent list items by using CSS columns (if supported)

## QA

- Pull code
- Run `./run serve --watch`
- Go to http://0.0.0.0:8102/vanilla-brochure-theme/examples/patterns/lists/split-list/
- Move from small screen to large screen and observe list items no longer sit rows of the same height
 
## Details

Fixes #83

## Screenshots

Before:

<img width="1092" alt="screen shot 2017-06-23 at 16 08 22" src="https://user-images.githubusercontent.com/505570/27488240-3c65f4c2-582e-11e7-89f3-ba9594a3c792.png">

After:

<img width="1084" alt="screen shot 2017-06-23 at 16 07 45" src="https://user-images.githubusercontent.com/505570/27488247-46666196-582e-11e7-8299-60ac6d40ca8f.png">


