### PR TITLE
Remove wrapping div from examples

### DIFF
--- a/_jekyll/_layouts/default.html
+++ b/_jekyll/_layouts/default.html
@@ -11,6 +11,6 @@
     {% endif %}
   </head>
   <body style="margin: 1rem;">
-    {{ content }}
+{{ content }}
   </body>
 </html>

--- a/_jekyll/_layouts/default.html
+++ b/_jekyll/_layouts/default.html
@@ -1,18 +1,16 @@
 <!DOCTYPE html>
-
 <html>
-    <head>
-        <meta charset="utf-8"/>
-         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <title>{% if page.title %} {{ page.title }} | {% endif %} {{ site.name }}</title>
-        {% if site.env == 'development' %}
-          <link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/build/css/build.css" />
-        {% else %}
-          <link rel="stylesheet" type="text/css" href="https://assets.ubuntu.com/latest-redirects/vanilla-brochure-theme.css" />
-        {% endif %}
-    </head>
-
-    <body style="margin: 1rem;">
-{{ content }}
-    </body>
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{% if page.title %} {{ page.title }} | {% endif %} {{ site.name }}</title>
+    {% if site.env == 'development' %}
+      <link rel="stylesheet" type="text/css" href="{{ site.baseurl }}/build/css/build.css" />
+    {% else %}
+      <link rel="stylesheet" type="text/css" href="https://assets.ubuntu.com/latest-redirects/vanilla-brochure-theme.css" />
+    {% endif %}
+  </head>
+  <body style="margin: 1rem;">
+    {{ content }}
+  </body>
 </html>

--- a/_jekyll/_layouts/default.html
+++ b/_jekyll/_layouts/default.html
@@ -12,9 +12,7 @@
         {% endif %}
     </head>
 
-    <body>
-      <div style="margin:1rem">
-       {{ content }}
-     </div>
+    <body style="margin: 1rem;">
+{{ content }}
     </body>
 </html>


### PR DESCRIPTION
## Done
Remove wrapping div from examples and add the margin to the body.

## QA
- Because this visible by example-js via gh-pages I believe a code review is sufficient for this review.

## Details
Fixes https://github.com/vanilla-framework/vanilla-brochure-theme/issues/100
