### PR TITLE
Add a link back to Vanilla documentation

### DIFF
--- a/docs/en/metadata.yaml
+++ b/docs/en/metadata.yaml
@@ -38,3 +38,6 @@ navigation:
 
     - location: utilities/image-position.md
       title: Image position
+
+- location: /
+  title: Vanilla framework


### PR DESCRIPTION
## Done
Add a link to Vanilla framework documentation

## QA

- Pull code
- Switch over to your docs.vanillaframework.io branch
- Create a file callled `build-local` with the follow content:
```bash
echo 'Building vanilla-frameworks documentation'
documentation-builder --base-directory ../vanilla-framework/docs  \
                      --site-root '/en/'  \
                      --output-path .  \
                      --template-path template.html  \
                      --tag-manager-code 'GTM-K92JCQ'  \
                      --no-link-extensions \
                      --force
echo 'Completed vanilla-framework documentation build'

echo 'Build vanilla-brochure-theme documentation'
documentation-builder --base-directory ../vanilla-brochure-theme/docs \
                      --site-root '/en/vanilla-brochure-theme' \
                      --output-path 'en/vanilla-brochure-theme' \
                      --template-path template.html \
                      --tag-manager-code 'GTM-K92JCQ'  \
                      --no-link-extensions \
                      --force

mv en/vanilla-brochure-theme/en/* en/vanilla-brochure-theme/.
rm -rf en/vanilla-brochure-theme/en/
echo 'Completed vanilla-brochure-theme documentation build'
```
- Run `./build-local`
- Run `caddy`
- Go to http://127.0.0.1:8543/en/vanilla-brochure-theme/
- Check that there is a link links to the vanilla-framework documentation.

