### PR TITLE
Combine the 3 list types into a single lists documentation page

### DIFF
--- a/docs/en/patterns/lists.md
+++ b/docs/en/patterns/lists.md
@@ -5,11 +5,11 @@ title: Lists
 
 # Lists
 If you want to display lists in a way that is more visually distinctive than
-the standard <ol> and <ul>, Vanilla brochure theme has 3 list styles at your
+the standard `<ol>` and `<ul>`, Vanilla brochure theme has 3 list styles at your
 disposal.
 
 
-## Ticked List
+## Ticked list
 
 The color of the tick icon is set by the `$color-accent` variable in `_settings.scss`.
 
@@ -18,7 +18,7 @@ The color of the tick icon is set by the `$color-accent` variable in `_settings.
   View example of the pattern list ticked
 </a>
 
-## Split List
+## Split list
 
 If you wish to split the items in a list into two columns above `$breakpoint-medium`, you can do so by adding the class `is-split` to the list element.
 
@@ -27,7 +27,7 @@ If you wish to split the items in a list into two columns above `$breakpoint-med
   View example of the patterns split list
 </a>
 
-## Stepped List
+## Stepped list
 
 Stepped list should be used for step by step instructions. This pattern is best
 used on a grey strip as the description sections are displayed in a white box.

--- a/docs/en/patterns/lists.md
+++ b/docs/en/patterns/lists.md
@@ -1,0 +1,48 @@
+---
+collection: patterns
+title: Lists
+---
+
+# Lists
+If you want to display lists in a way that is more visually distinctive than
+the standard <ol> and <ul>, Vanilla brochure theme has 3 list styles at your
+disposal.
+
+
+## Ticked List
+
+The color of the tick icon is set by the `$color-accent` variable in `_settings.scss`.
+
+<a href="https://vanilla-framework.github.io/vanilla-brochure-theme/examples/patterns/lists/ticked-list/"
+  class="js-example">
+  View example of the pattern list ticked
+</a>
+
+## Split List
+
+If you wish to split the items in a list into two columns above `$breakpoint-medium`, you can do so by adding the class `is-split` to the list element.
+
+<a href="https://vanilla-framework.github.io/vanilla-brochure-theme/examples/patterns/lists/split-list/"
+  class="js-example">
+  View example of the patterns split list
+</a>
+
+## Stepped List
+
+Stepped list should be used for step by step instructions. This pattern is best
+used on a grey strip as the description sections are displayed in a white box.
+
+<a href="https://vanilla-framework.github.io/vanilla-brochure-theme/examples/patterns/lists/stepped-list-detailed/"
+  class="js-example">
+  View example of the pattern stepped list detailed
+</a>
+
+
+---
+
+#### Vanilla patterns
+
+These patterns are an extention or addition of the patterns available on Vanilla
+framework.
+
+[Vanilla framework list patterns](https://docs.vanillaframework.io/en/patterns/lists)


### PR DESCRIPTION
## Done
Combine the 3 list types into a single lists documentation page

## QA
- Check the code that no content is lost

## Details
Fixes https://github.com/ubuntudesign/docs.vanillaframework.io/issues/101

