### PR TITLE
Change the back to Vanilla to parent link style

### DIFF
--- a/docs/en/metadata.yaml
+++ b/docs/en/metadata.yaml
@@ -40,4 +40,6 @@ navigation:
       title: Image position
 
 - location: /
-  title: Vanilla framework
+  title: docs.vanillaframework.io
+  external: true
+


### PR DESCRIPTION
## Done
Change the back to Vanilla to parent link style. Mentioned in this issue: https://github.com/ubuntudesign/docs.vanillaframework.io/issues/100

## QA
- Pull this branch
- Run `documentation-builder --source-folder docs`
- Then open the docs with `xdg-open build/en/index.html`
- Check that the link at the bottom of the navigation is docs.vanillaframework.io