### PR TITLE
Add brochure theme to the site title in docs

### DIFF
--- a/docs/metadata.yaml
+++ b/docs/metadata.yaml
@@ -1,4 +1,4 @@
 site_favicon: "https://assets.ubuntu.com/v1/383ca4d9-vanilla_favicon_16px.svg"
 site_logo_url: "https://assets.ubuntu.com/v1/d96d86b5-vanilla_black-orange_hex.svg"
-site_title: ~
+site_title: brochure theme documentation
 


### PR DESCRIPTION
## Done
Added brochure theme documentation to the site title as mentioned in https://github.com/ubuntudesign/docs.vanillaframework.io/issues/100

## QA
- Make sure you have the latest version of documentation-builder 1.4.1 or greater
- Run `documentation-builder --source-folder docs`
- Run `xdg-open build/en/index.html`
- Check that the title by the logo says "brochure theme documentation"
